### PR TITLE
Call init() if mimetype is not found with preinit()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,13 +84,7 @@ jobs:
           python3 -m pip install pytest-reverse
         fi
         if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-          export XDG_RUNTIME_DIR="/tmp/headless-sway"
-          export SWAYSOCK="$XDG_RUNTIME_DIR/sway.sock"
-          export WLR_BACKENDS=headless
-          export WLR_LIBINPUT_NO_DEVICES=1
-          mkdir "$XDG_RUNTIME_DIR"
-          xvfb-run -s '-screen 0 1024x768x24'\
-                  sway -V -d -c /dev/null&
+          xvfb-run -s '-screen 0 1024x768x24' sway&
           export WAYLAND_DISPLAY=wayland-1
           .ci/test.sh
         else

--- a/Tests/test_imagegrab.py
+++ b/Tests/test_imagegrab.py
@@ -106,11 +106,10 @@ $ms = new-object System.IO.MemoryStream(, $bytes)
         ),
         reason="Linux with wl-clipboard only",
     )
-    @pytest.mark.parametrize(
-        "image_path", ["Tests/images/hopper.gif", "Tests/images/hopper.png"]
-    )
-    def test_grabclipboard_wl_clipboard(self, image_path):
-        with open(image_path, mode="rb") as raw_image:
-            subprocess.call(["wl-copy"], stdin=raw_image)
+    @pytest.mark.parametrize("ext", ("gif", "png", "ico"))
+    def test_grabclipboard_wl_clipboard(self, ext):
+        image_path = "Tests/images/hopper." + ext
+        with open(image_path, "rb") as fp:
+            subprocess.call(["wl-copy"], stdin=fp)
             im = ImageGrab.grabclipboard()
             assert_image_equal_tofile(im, image_path)

--- a/src/PIL/ImageGrab.py
+++ b/src/PIL/ImageGrab.py
@@ -137,11 +137,19 @@ def grabclipboard():
             args = ["wl-paste"]
             output = subprocess.check_output(["wl-paste", "-l"]).decode()
             clipboard_mimetypes = output.splitlines()
+
+            def find_mimetype():
+                for mime in Image.MIME.values():
+                    if mime in clipboard_mimetypes:
+                        return mime
+
             Image.preinit()
-            for mimetype in Image.MIME.values():
-                if mimetype in clipboard_mimetypes:
-                    args.extend(["-t", mimetype])
-                    break
+            mimetype = find_mimetype()
+            if not mimetype:
+                Image.init()
+                mimetype = find_mimetype()
+            if mimetype:
+                args.extend(["-t", mimetype])
         elif shutil.which("xclip"):
             args = ["xclip", "-selection", "clipboard", "-t", "image/png", "-o"]
         else:


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/7094

- I went through test.yml and removed any of new settings I could while still having wl-paste work.
- I updated ImageGrab.py to use `Image.init()` if `Image.preinit()` isn't sufficient. To explain a bit further, `preinit()` [imports five of the formats](https://github.com/python-pillow/Pillow/blob/1321b6e09cd0889c8aa422174800bf21728ce88d/src/PIL/Image.py#L301-L337) - BMP, GIF, JPEG, PPM and PNG, and then `init()` imports the rest if that wasn't enough. This is what is done in [`open()`](https://github.com/python-pillow/Pillow/blob/1321b6e09cd0889c8aa422174800bf21728ce88d/src/PIL/Image.py#L3210-L3244).